### PR TITLE
Log recovery email selection during Google account creation

### DIFF
--- a/buat_akun.py
+++ b/buat_akun.py
@@ -56,7 +56,9 @@ def get_email_pemulihan():
         if not emails:
             log_action("fatal", f"File '{FILE_EMAIL_PEMULIHAN}' kosong.")
             return None
-        return random.choice(emails)
+        chosen_email = random.choice(emails)
+        log_action("info", f"Email pemulihan dipilih: {chosen_email}")
+        return chosen_email
     except FileNotFoundError:
         log_action("fatal", f"File '{FILE_EMAIL_PEMULIHAN}' tidak ditemukan.")
         return None


### PR DESCRIPTION
## Summary
- Log the selected recovery email when loading from `recovery_emails.txt`

## Testing
- `python -m py_compile buat_akun.py`


------
https://chatgpt.com/codex/tasks/task_e_68964389d130832199a957838e45f8cc